### PR TITLE
update: describe "#runner"

### DIFF
--- a/spec/blackjack_spec.rb
+++ b/spec/blackjack_spec.rb
@@ -127,7 +127,7 @@ describe "#runner" do
   -until- the card sum is greater than 21,
   then calls on the #end_game method" do
 
-    expect(self).to receive(:deal_card).at_least(3).times.and_return(10)
+    expect(self).to receive(:deal_card).at_least(2).times.and_return(10)
     expect(self).to receive(:get_user_input).and_return("h")
 
     expect($stdout).to receive(:puts).with("Welcome to the Blackjack Table")


### PR DESCRIPTION
expect(self).to receive(:deal_card).at_least(2).times , not 3 times.

I think we want it to listen for the #deal_card method two times, since initial round executes it twice, as per blackjack rules?